### PR TITLE
Client: migrate to async reqwest_impersonate::Client, use rayon ThreadPool and Tokio multi-thread runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,9 +201,9 @@ checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "cc"
-version = "1.0.95"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32a725bc159af97c3e629873bb9f88fb8cf8a4867175f76dc987815ea07c83b"
+checksum = "065a29261d53ba54260972629f9ca6bffa69bac13cd1fed61420f7fa68b9f8bd"
 
 [[package]]
 name = "cexpr"
@@ -292,6 +292,31 @@ checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
 name = "deranged"
@@ -391,12 +416,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
-name = "futures-io"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
-
-[[package]]
 name = "futures-sink"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -415,12 +434,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures-core",
- "futures-io",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
- "slab",
 ]
 
 [[package]]
@@ -918,8 +934,10 @@ dependencies = [
  "encoding_rs",
  "pyo3",
  "pythonize",
+ "rayon",
  "reqwest-impersonate",
  "serde_json",
+ "tokio",
 ]
 
 [[package]]
@@ -939,6 +957,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -981,9 +1019,9 @@ checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "reqwest-impersonate"
-version = "0.11.72"
+version = "0.11.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b725314a794f526bac22292a10e2bf581cbea5ebd527fa3032e2cfd829068be"
+checksum = "78ba0d953bf10f7aa5d454bc8d9136efd94c3cfb4d6db4f02323b54957f7310f"
 dependencies = [
  "async-compression",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ crate-type = ["cdylib"]
 pyo3 = { version = "0.21", features = ["extension-module", "abi3-py38"] }
 reqwest-impersonate = { version = "0.11", default-features = false, features = [
     "cookies",
-    "blocking",
     "boring-tls",
     "impersonate",
     "json",
@@ -28,6 +27,8 @@ reqwest-impersonate = { version = "0.11", default-features = false, features = [
 encoding_rs = "0.8"
 pythonize = "0.21"
 serde_json = "1"
+tokio = { version = "1", features = ["fs", "rt-multi-thread"] }
+rayon = "1"
 
 [profile.release]
 codegen-units = 1

--- a/src/response.rs
+++ b/src/response.rs
@@ -22,7 +22,7 @@ pub struct Response {
     #[pyo3(get)]
     pub status_code: Py<PyAny>,
     #[pyo3(get)]
-    pub url: Py<PyAny>,
+    pub url: Py<PyString>,
 }
 
 #[pymethods]


### PR DESCRIPTION
1) Client: migrate to async reqwest_impersonate::Client,
2) Use rayon ThreadPool and Tokio multi-thread runtime to execute future and bypass Python thread deadlock.