### PR TITLE
Ci: use `manylinux=2_28` for linux builds, add `musllinux` builds

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,7 +41,7 @@ jobs:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --zig
           sccache: 'true'
-          manylinux: auto
+          manylinux: 2_28
         env:
           CFLAGS_aarch64_unknown_linux_gnu: "-D__ARM_ARCH=8"
       - name: Upload wheels

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -59,7 +59,7 @@ jobs:
           pytest
       - name: pytest
         if: ${{ !startsWith(matrix.platform.target, 'x86') && matrix.platform.target != 'ppc64' }}
-        uses: uraimo/run-on-arch-action@v2.5.0
+        uses: uraimo/run-on-arch-action@v2.7.2
         with:
           arch: ${{ matrix.platform.target }}
           distro: ubuntu22.04
@@ -70,6 +70,60 @@ jobs:
             pip3 install -U pip pytest
           run: |
             set -e
+            pip3 install pyreqwest_impersonate --no-index --find-links dist --force-reinstall
+            pytest
+
+  musllinux:
+    runs-on: ${{ matrix.platform.runner }}
+    strategy:
+      matrix:
+        platform:
+          - runner: ubuntu-latest
+            target: x86_64
+          - runner: ubuntu-latest
+            target: aarch64
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist --zig
+          sccache: 'true'
+          manylinux: musllinux_1_2
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-linux-${{ matrix.platform.target }}-musllinux_1_2
+          path: dist
+      - name: pytest
+        if: ${{ startsWith(matrix.platform.target, 'x86_64') }}
+        uses: addnab/docker-run-action@v3
+        with:
+          image: quay.io/pypa/musllinux_1_2_${{ matrix.platform.target }}:latest
+          options: -v ${{ github.workspace }}:/io -w /io
+          run: |
+            python3 -m venv .venv
+            source .venv/bin/activate
+            python3 -m pip install -U pip wheel pytest
+            python3 -m pip install pyreqwest_impersonate --no-index --find-links dist/ --force-reinstall
+            python3 -m pytest
+      - name: pytest
+        if: ${{ !startsWith(matrix.platform.target, 'x86') && matrix.platform.target != 'ppc64' }}
+        uses: uraimo/run-on-arch-action@v2.7.2
+        with:
+          arch: ${{ matrix.platform.target }}
+          distro: alpine_latest
+          githubToken: ${{ github.token }}
+          install: |
+            apk add py3-pip
+            python3 -m venv /opt/venv
+            /opt/venv/bin/pip3 install -U pip pytest
+          run: |
+            source /opt/venv/bin/activate
             pip3 install pyreqwest_impersonate --no-index --find-links dist --force-reinstall
             pytest
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.12'
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
@@ -86,7 +86,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.12'
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
@@ -138,7 +138,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.12'
           architecture: ${{ matrix.platform.target }}
       - name: Install nasm
         run: choco install nasm
@@ -175,7 +175,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.12'
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
@@ -237,7 +237,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.12'
       - name: Install dependencies
         run: |
           sleep 30  # Wait for the package to be available on PyPI

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The fastest python HTTP client that can impersonate web browsers by mimicking th
 Binding to the Rust [reqwest_impersonate](https://github.com/gngpp/reqwest-impersonate) library.</br>
 
 Provides precompiled wheels:
-- [x] Linux:  `amd64`, `aarch64`, `armv7`.
+- [x] Linux:  `amd64`, `aarch64`, `armv7`; musllinux:  `amd64`, `aarch64`.
 - [x] Windows: `amd64`.
 - [x] MacOS:  `amd64`, `aarch64`.
 
@@ -16,7 +16,6 @@ Provides precompiled wheels:
 - [Usage](#usage)
  - [I. Client](#i-client)
  - [II. AsyncClient](#ii-asyncclient)
-
 
 ## Installation
 


### PR DESCRIPTION
1) use `manylinux=2_28` for linux builds, 
2) add `musllinux` builds,
3) Update python from `3.10` to `3.12` for all steps.