### PR TITLE
Migrate to `nightly` rust-toolchain

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
+          rust-toolchain: nightly
           target: ${{ matrix.platform.target }}
           args: --release --out dist --zig
           sccache: 'true'
@@ -90,6 +91,7 @@ jobs:
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
+          rust-toolchain: nightly
           target: ${{ matrix.platform.target }}
           args: --release --out dist --zig
           sccache: 'true'
@@ -145,6 +147,7 @@ jobs:
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
+          rust-toolchain: nightly
           target: ${{ matrix.platform.target }}
           args: --release --out dist
           sccache: 'true'
@@ -179,6 +182,7 @@ jobs:
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
+          rust-toolchain: nightly
           target: ${{ matrix.platform.target }}
           args: --release --out dist
           sccache: 'true'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,8 +28,6 @@ jobs:
             target: x86_64
           - runner: ubuntu-latest
             target: aarch64
-          - runner: ubuntu-latest
-            target: armv7
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
 
 [[package]]
+name = "any_all_workaround"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88fea40735f2cc320a5133ce772d39c571bd6c9b0d4c1a326926eecdd5af2e86"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -339,6 +348,7 @@ version = "0.8.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
 dependencies = [
+ "any_all_workaround",
  "cfg-if",
 ]
 
@@ -1019,9 +1029,9 @@ checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "reqwest-impersonate"
-version = "0.11.75"
+version = "0.11.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ba0d953bf10f7aa5d454bc8d9136efd94c3cfb4d6db4f02323b54957f7310f"
+checksum = "72f5de030049c9f3a4a6ba4abe11c451ec3464eae3fa1e55020514891f3f5953"
 dependencies = [
  "async-compression",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ reqwest-impersonate = { version = "0.11", default-features = false, features = [
     "brotli",
     "deflate",
 ] }
-encoding_rs = "0.8"
+encoding_rs = { version = "0.8", features = ["simd-accel"] }
 pythonize = "0.21"
 serde_json = "1"
 tokio = { version = "1", features = ["fs", "rt-multi-thread"] }

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The fastest python HTTP client that can impersonate web browsers by mimicking th
 Binding to the Rust [reqwest_impersonate](https://github.com/gngpp/reqwest-impersonate) library.</br>
 
 Provides precompiled wheels:
-- [x] Linux:  `amd64`, `aarch64`, `armv7`; musllinux:  `amd64`, `aarch64`.
+- [x] Linux|musl:  `amd64`, `aarch64`.
 - [x] Windows: `amd64`.
 - [x] MacOS:  `amd64`, `aarch64`.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ pip install -U pyreqwest_impersonate
 ## Key Features
 - Impersonate: The Client offers an `impersonate` option, enabling it to mimic web browsers by replicating their headers and TLS/JA3/JA4/HTTP2 fingerprints.
 - Thread-safe: The Client is designed to be thread-safe, allowing it to be safely used in multithreaded environments.
-- Automatic Character Encoding Detection: The encoding is taken from the "Content-Type" header, but if not specified, "UTF-8".
+- Automatic Character Encoding Detection: The encoding is taken from the "Content-Type" header, but if not specified, "UTF-8". If encoding does not match the content, the package automatically detects and uses the correct encoding to decode the text.
 - Small Size: The compiled library is about 5.8MB in size.
 - High Performance: The library is designed for a large number of threads, uses all processors, and releases the GIL. All operations like accessing headers, decoding text, or parsing JSON are executed in Rust.
 


### PR DESCRIPTION
1) [CI: use nightly rust-toolchain](https://github.com/deedy5/pyreqwest_impersonate/commit/1395975e9234a2910b97a8f3c685f4d379daa557),
2) [encoding-rs: enable simd-accel feature, drop armv7 support](https://github.com/deedy5/pyreqwest_impersonate/commit/ba320477df3f92ccb2bb436e84d377ef7f10c878),
3) [README: update Automatic Character Encoding Detection section](https://github.com/deedy5/pyreqwest_impersonate/commit/1219df35ea0370eeaca8cb5c435cee2208af93f2)