### PR TITLE
[html2text] Response object: 1) add attribute `text_plain`, 2) rename attribute `plaintext` to `text_markdown`

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,9 +127,10 @@ resp.cookies
 resp.encoding
 resp.headers
 resp.json()
-resp.plaintext  # html is converted to markdown text
 resp.status_code
 resp.text
+resp.text_markdown  # html is converted to markdown text
+resp.text_plain  # html is converted to plain text
 resp.url
 ```
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -68,7 +68,7 @@ impl Response {
     #[getter]
     fn text_markdown(&mut self, py: Python) -> PyResult<String> {
         let raw_bytes = self.content.bind(py).as_bytes();
-        let text = from_read(raw_bytes, 1080);
+        let text = from_read(raw_bytes, usize::MAX);
         Ok(text)
     }
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -66,7 +66,7 @@ impl Response {
     }
 
     #[getter]
-    fn plaintext(&mut self, py: Python) -> PyResult<String> {
+    fn text_markdown(&mut self, py: Python) -> PyResult<String> {
         let raw_bytes = self.content.bind(py).as_bytes();
         let text = from_read(raw_bytes, 1080);
         Ok(text)

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,5 +1,5 @@
 use encoding_rs::Encoding;
-use html2text::from_read;
+use html2text::{from_read, from_read_with_decorator, render::text_renderer::TrivialDecorator};
 use pyo3::exceptions;
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict, PyString};
@@ -69,6 +69,13 @@ impl Response {
     fn text_markdown(&mut self, py: Python) -> PyResult<String> {
         let raw_bytes = self.content.bind(py).as_bytes();
         let text = from_read(raw_bytes, usize::MAX);
+        Ok(text)
+    }
+
+    #[getter]
+    fn text_plain(&mut self, py: Python) -> PyResult<String> {
+        let raw_bytes = self.content.bind(py).as_bytes();
+        let text = from_read_with_decorator(raw_bytes, usize::MAX, TrivialDecorator::new());
         Ok(text)
     }
 }


### PR DESCRIPTION
Response object: 
1) add attribute `text_plain`,
2) rename attribute `plaintext` to `text_markdown`.